### PR TITLE
Adding Unit section to service file.

### DIFF
--- a/tempcontrol.service
+++ b/tempcontrol.service
@@ -1,3 +1,4 @@
+[Unit]
 Description=Automatic fan control of R720xd
 After=network.target
 


### PR DESCRIPTION
The service file was not working without the `[Unit]` section header at the top.